### PR TITLE
anaconda-client 1.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-client" %}
-{% set version = "1.8.0" %}
-{% set checksum = "be97ef87be4e9076db91c0aaee4a4dc30e2527c8d87c63c8a0c12cd6fd269d95" %}
+{% set version = "1.9.0" %}
+{% set checksum = "78f64f3b3b556f5b939f742b69d50d4046f8dc3a5414c072447386ab9cb74deb" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Update anaconda-client to 1.9.0

Category: anaconda | subcategory: core | pkg_type: python
Popularity: 2270637 downloads - ana-client 1.8.0 Ana Cloud command line client library
Version change: bump version number from 1.8.0 to 1.9.0
license: BSD 3-Clause
Bug Tracker: new open issues https://github.com/Anaconda-Platform/anaconda-client/issues
Github releases: https://github.com/Anaconda-Platform/anaconda-client/releases
Upstream Changelog: https://github.com/Anaconda-Platform/anaconda-client/blob/master/CHANGELOG.md
Upstream setup.py: https://github.com/Anaconda-Platform/anaconda-client/blob/1.9.0/setup.py
and https://github.com/Anaconda-Platform/anaconda-client/blob/1.9.0/requirements.txt

The package anaconda-client is mentioned inside the packages:
anaconda-project | conda-repo-cli | nb_anacondacloud |

Actions:
1. No actions

Result:
- all-succeeded