### PR TITLE
DNM: Switch to noarch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,8 @@ source:
   sha256: 96990e99d9c13e67e88c5a943936ae3596dcf6c4676175569e1b0aac3980cb12
 
 build:
-  number: 0
+  number: 1
+  noarch: python
   script: {{ PYTHON }} -m pip install --no-build-isolation --no-deps . -vv
   entry_points:
     - binstar = binstar_client.scripts.cli:main


### PR DESCRIPTION
anaconda-client 1.13.1 noarch

**Destination channel:** defaults

### Links

- [PKG-9677](https://anaconda.atlassian.net/browse/PKG-9677) 
- [Upstream repository](https://github.com/anaconda/anaconda-client)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-client/compare/1.13.0...1.13.1)
- [PBP]()

### Explanation of changes:

- noarch build so we can support osx-64