### PR TITLE
Release 1.14.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: true # [py<310]
   script: {{ PYTHON }} -m pip install --no-build-isolation --no-deps . -vv
   entry_points:
     - binstar = binstar_client.scripts.cli:main
@@ -18,7 +19,7 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.10
+    - python
     - hatchling
     - hatch-vcs >=0.3
     - setuptools-scm >=7.1
@@ -26,7 +27,7 @@ requirements:
   run:
     # Based on:
     # requirements.txt, conda.recipe/meta.yaml, requirements-extra.txt
-    - python >=3.10
+    - python
     - anaconda-anon-usage >=0.7.3
     - anaconda-cli-base >=0.7.0
     - anaconda-auth >=0.12.3
@@ -44,7 +45,7 @@ requirements:
     - urllib3 >=1.26.4
   run_constrained:
     - anaconda-project >=0.9.1
-    - pillow >=8.2
+    - pillow >=10.2.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,6 +88,10 @@ about:
   description: |
     Anaconda-client is used to connect to and manage your packages on anaconda.org, upload packages you have created
     and generate access tokens to allow access to private packages.
-  doc_url: https://docs.anaconda.com/anacondaorg/
-  doc_source_url: https://github.com/anaconda/anaconda-client/blob/main/README.md
+  doc_url: https://www.anaconda.com/docs/tools/anaconda-org
   dev_url: https://github.com/anaconda/anaconda-client
+
+extra:
+  skip-lints:
+    - python_build_tools_in_host
+    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/anaconda/anaconda-client/archive/${{ version }}.tar.gz
+  url: https://github.com/anaconda/anaconda-client/archive/{{ version }}.tar.gz
   sha256: 8a87e229021727bc357777a49fdc7b8d9299beb2dbe463dbe2b9092cf95d0684
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "1.14.0" %}
+{% set version = "1.14.1" %}
 
 package:
   name: anaconda-client
   version: {{ version }}
 
 source:
-  url: https://github.com/Anaconda-Platform/anaconda-client/archive/{{ version }}.tar.gz
-  sha256: 2f3f26bff6753d5a55bc21736626080613a34848a1f4072afad5f56775a2bd85
+  url: https://github.com/anaconda/anaconda-client/archive/${{ version }}.tar.gz
+  sha256: 8a87e229021727bc357777a49fdc7b8d9299beb2dbe463dbe2b9092cf95d0684
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,8 +85,8 @@ about:
   license_file: LICENSE.md
   summary: anaconda.org command line client library
   description: |
-    Anaconda-client is used to connect to and manage your Anaconda Cloud account, upload packages you have created
+    Anaconda-client is used to connect to and manage your packages on anaconda.org, upload packages you have created
     and generate access tokens to allow access to private packages.
   doc_url: https://docs.anaconda.com/anacondaorg/
-  doc_source_url: https://github.com/anaconda/anaconda-client/blob/master/README.md
+  doc_source_url: https://github.com/anaconda/anaconda-client/blob/main/README.md
   dev_url: https://github.com/anaconda/anaconda-client

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   host:
     - pip
-    - python
+    - python >=3.10
     - hatchling
     - hatch-vcs >=0.3
     - setuptools-scm >=7.1
@@ -26,10 +26,10 @@ requirements:
   run:
     # Based on:
     # requirements.txt, conda.recipe/meta.yaml, requirements-extra.txt
-    - python
+    - python >=3.10
     - anaconda-anon-usage >=0.7.3
-    - anaconda-cli-base >=0.5.3
-    - anaconda-auth >=0.11.0 # minimum effectively required
+    - anaconda-cli-base >=0.7.0
+    - anaconda-auth >=0.12.3
     - conda-package-handling >=1.7.3
     - defusedxml >=0.7.1
     - nbformat >=4.4.0


### PR DESCRIPTION
## Summary

Update for `anaconda-client=1.14.1`. This is a patch release with minor bug fixes.

* [Release Notes](https://github.com/anaconda/anaconda-client/releases/tag/1.14.1)
* [conda-forge update](https://github.com/conda-forge/anaconda-client-feedstock/pull/62)

### Dependency updates

* Update minimum: `python >=3.10`
* Update minimum: `anaconda-auth >=0.12.3`
* Update minimum: `anaconda-cli-base >=0.7.0`